### PR TITLE
Remove reference to deleted DB field

### DIFF
--- a/api/resources/summarization_gene_expression.py
+++ b/api/resources/summarization_gene_expression.py
@@ -166,7 +166,6 @@ class SummarizationGeneExpressionUser(Resource):
                         row.first_name,
                         row.last_name,
                         row.email,
-                        row.contact_type,
                     ]
                 )
                 for row in rows


### PR DESCRIPTION
Removing a reference to a field that was deleted in the last commit that may cause errors