### PR TITLE
Validate captcha values inside /request

### DIFF
--- a/api/resources/api_manager.py
+++ b/api/resources/api_manager.py
@@ -38,22 +38,19 @@ class ApiManagerUtils:
             return False
 
     @staticmethod
-    def validate_captcha(self):
+    def validate_captcha(value):
         """Validates a reCaptcha value using our secret token"""
-        if request.method == "POST":
-            json = request.get_json()
-            value = json["response"]
-            with open(CAPTCHA_KEY_FILE, "rb") as f:
-                for line in f:
-                    key = line
-            if key:
-                ret = requests.post(
-                    "https://www.google.com/recaptcha/api/siteverify",
-                    data={"secret": key, "response": value}
-                )
-                return ret.json()["success"]
-            else:
-                return False
+        with open(CAPTCHA_KEY_FILE, "rb") as f:
+            for line in f:
+                key = line
+        if key:
+            ret = requests.post(
+                "https://www.google.com/recaptcha/api/siteverify",
+                data={"secret": key, "response": value}
+            )
+            return ret.json()["success"]
+        else:
+            return False
 
     @staticmethod
     def send_email_notification():

--- a/api/resources/api_manager.py
+++ b/api/resources/api_manager.py
@@ -40,17 +40,20 @@ class ApiManagerUtils:
     @staticmethod
     def validate_captcha(value):
         """Validates a reCaptcha value using our secret token"""
-        with open(CAPTCHA_KEY_FILE, "rb") as f:
-            for line in f:
-                key = line
-        if key:
-            ret = requests.post(
-                "https://www.google.com/recaptcha/api/siteverify",
-                data={"secret": key, "response": value}
-            )
-            return ret.json()["success"]
+        if(os.environ.get("BAR")):
+            with open(CAPTCHA_KEY_FILE, "rb") as f:
+                for line in f:
+                    key = line
+            if key:
+                ret = requests.post(
+                    "https://www.google.com/recaptcha/api/siteverify",
+                    data={"secret": key, "response": value}
+                )
+                return ret.json()["success"]
+            else:
+                return False
         else:
-            return False
+            return True
 
     @staticmethod
     def send_email_notification():

--- a/api/resources/api_manager.py
+++ b/api/resources/api_manager.py
@@ -39,34 +39,35 @@ class ApiManagerUtils:
 
     @staticmethod
     def send_email_notification():
-        with open(os.environ.get("ADMIN_EMAIL"), "r") as f:
-            for line in f:
-                recipient = line
-        port = 465
-        key = os.environ.get('EMAIL_PASS_KEY')
-        cipher_suite = Fernet(key)
-        with open(os.environ.get('EMAIL_PASS_FILE'), "rb") as f:
-            for line in f:
-                encrypted_key = line
-        uncipher_text = cipher_suite.decrypt(encrypted_key)
-        password = bytes(uncipher_text).decode("utf-8")
-        context = create_default_context()
-        smtp_server = 'smtp.gmail.com'
-        sender_email = 'bar.summarization@gmail.com'
-        subject = "[Bio-Analytic Resource] New API key request"
-        text = """\
-            There is a new API key request.
-            You can approve or reject it at http://bar.utoronto.ca/~bpereira/webservices/bar-request-manager/build/index.html
-        """
-        m_text = MIMEText(text, _subtype='plain', _charset='UTF-8')
-        msg = MIMEMultipart()
-        msg["From"] = sender_email
-        msg["To"] = recipient
-        msg["Subject"] = subject
-        msg.attach(m_text)
-        with SMTP_SSL(smtp_server, port, context=context) as server:
-            server.login("bar.summarization@gmail.com", password)
-            server.sendmail(sender_email, recipient, msg.as_string())
+        if os.environ.get("BAR"):
+            with open(os.environ.get("ADMIN_EMAIL"), "r") as f:
+                for line in f:
+                    recipient = line
+            port = 465
+            key = os.environ.get('EMAIL_PASS_KEY')
+            cipher_suite = Fernet(key)
+            with open(os.environ.get('EMAIL_PASS_FILE'), "rb") as f:
+                for line in f:
+                    encrypted_key = line
+            uncipher_text = cipher_suite.decrypt(encrypted_key)
+            password = bytes(uncipher_text).decode("utf-8")
+            context = create_default_context()
+            smtp_server = 'smtp.gmail.com'
+            sender_email = 'bar.summarization@gmail.com'
+            subject = "[Bio-Analytic Resource] New API key request"
+            text = """\
+                There is a new API key request.
+                You can approve or reject it at http://bar.utoronto.ca/~bpereira/webservices/bar-request-manager/build/index.html
+            """
+            m_text = MIMEText(text, _subtype='plain', _charset='UTF-8')
+            msg = MIMEMultipart()
+            msg["From"] = sender_email
+            msg["To"] = recipient
+            msg["Subject"] = subject
+            msg.attach(m_text)
+            with SMTP_SSL(smtp_server, port, context=context) as server:
+                server.login("bar.summarization@gmail.com", password)
+                server.sendmail(sender_email, recipient, msg.as_string())
 
 
 @api_manager.route("/validate_admin_password", methods=["POST"], doc=False)


### PR DESCRIPTION
Moved captcha validation into the /request endpoint to prevent it from ever running without valid captcha