### PR TITLE
fixed regex for get_trees and timeseries endpoints in FastPheno to accept individual trees via . like 619.03

### DIFF
--- a/api/resources/fastpheno.py
+++ b/api/resources/fastpheno.py
@@ -83,7 +83,7 @@ class FastPhenoTrees(Resource):
         tree_site_id = str(escape(tree_site_id))
         site = request.args.get("site")
 
-        if not re.search(r"^[a-zA-Z0-9]{1,10}$", tree_site_id):
+        if not re.search(r"^[a-zA-Z0-9.]{1,15}$", tree_site_id):
             return BARUtils.error_exit("Invalid tree site ID"), 400
 
         if site is not None:
@@ -179,7 +179,7 @@ class FastPhenoGenotypeTimeSeries(Resource):
         band = str(escape(band))
         site = request.args.get("site")
 
-        if not re.search(r"^[a-zA-Z0-9]{1,10}$", tree_site_id):
+        if not re.search(r"^[a-zA-Z0-9.]{1,15}$", tree_site_id):
             return BARUtils.error_exit("Invalid tree site ID"), 400
 
         if not re.search(r"^[a-zA-Z0-9_]{1,20}$", band):

--- a/tests/resources/test_fastpheno.py
+++ b/tests/resources/test_fastpheno.py
@@ -152,8 +152,8 @@ class TestIntegrations(TestCase):
         expected = {"wasSuccessful": False, "error": "No data found for the given parameters"}
         self.assertEqual(response.json, expected)
 
-        # Invalid tree_site_id (too long)
-        response = self.app_client.get("/fastpheno/get_trees/TOOLONGID12345")
+        # Invalid tree_site_id (contains disallowed character)
+        response = self.app_client.get("/fastpheno/get_trees/619!")
         expected = {"wasSuccessful": False, "error": "Invalid tree site ID"}
         self.assertEqual(response.json, expected)
 
@@ -231,8 +231,8 @@ class TestIntegrations(TestCase):
         expected = {"wasSuccessful": False, "error": "No data found for the given parameters"}
         self.assertEqual(response.json, expected)
 
-        # Invalid tree_site_id (too long)
-        response = self.app_client.get("/fastpheno/timeseries/genotype/TOOLONGID123/398nm/aggregate")
+        # Invalid tree_site_id (contains disallowed character)
+        response = self.app_client.get("/fastpheno/timeseries/genotype/619!/398nm/aggregate")
         expected = {"wasSuccessful": False, "error": "Invalid tree site ID"}
         self.assertEqual(response.json, expected)
 


### PR DESCRIPTION
Needed for frontend development asap @asherpasha thanks.